### PR TITLE
Preliminary token revocation support

### DIFF
--- a/pyramid_oauthlib/__init__.py
+++ b/pyramid_oauthlib/__init__.py
@@ -10,14 +10,20 @@ log = logging.getLogger(__name__)
 
 OAUTH_PARAMS = (
     'access_token',
+    'client',
     'client_id',
     'client_secret',
     'code',
     'grant_type',
-    'response_type',
+    'password',
     'redirect_uri',
+    'refresh_token',
+    'response_type',
     'scope',
     'state',
+    'token',
+    'user',
+    'username',
 )
 
 
@@ -63,7 +69,15 @@ class Server(
 
     @base.catch_errors_and_unavailability
     def create_revocation_response(self, request):
-        pass
+        handler = self.response_types.get(
+            request.response_type,
+            self.default_response_type_handler,
+        )
+        return handler.create_revocation_response(
+            request.url,
+            request.method,
+            request.body,
+            request.headers)
 
     @base.catch_errors_and_unavailability
     def create_token_response(self, request, credentials=None):
@@ -204,7 +218,9 @@ def includeme(config):
 
     config.add_request_method(
         lambda request:
-        server.create_revocation_response(request),
+        oauth_response(
+            server.create_revocation_response(request)
+        ),
         str('create_revocation_response'))
 
     config.add_request_method(


### PR DESCRIPTION
Hi

I've started testing `pyramid-oauthlib` and would like to use it in a project. I have interest in supporting token revocation and have managed to get it roughly working with the given changes. I'd be interested in knowing your plans on how to properly implement it and would be happy to work on this part.

One issue I noticed is that the `RevocationEndPoint.create_revocation_response` builds the request object itself and passes that to the `RequestValidator.validate_revocation_request` method. This breaks the promise that the request parameters passed to the custom validator would be `pyramid.request.Request` instead of `oauthlib.common.Request`.

Looking forward to your comments.
