### PR TITLE
fixed duplicate_params

### DIFF
--- a/pyramid_oauthlib/__init__.py
+++ b/pyramid_oauthlib/__init__.py
@@ -168,6 +168,7 @@ def duplicate_params(request):
     keys = list(request.params)
     return [k for k in keys if keys.count(k) > 1]
 
+
 def oauth_response(result):
     headers, body, status = result
     return Response(body=body, status=status, headers={
@@ -233,7 +234,7 @@ def includeme(config):
         str('verify_request'))
 
     config.add_request_method(
-        lambda request: duplicate_params,
+        lambda request: duplicate_params(request),
         str("duplicate_params"),
         property=True
     )


### PR DESCRIPTION
This PR fixes the `duplicate_params` request method. Didn't work for me without this patch.